### PR TITLE
Changed game text colors to green

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -190,7 +190,7 @@ var TitleScreen = function TitleScreen(title, subtitle, callback) {
   };
 
   this.draw = function (ctx) {
-    ctx.fillStyle = "#FFFFFF";
+    ctx.fillStyle = "#00FF00";
 
     ctx.font = "bold 40px bangers";
     var measure = ctx.measureText(title);
@@ -480,7 +480,7 @@ var GamePoints = function () {
   this.draw = function (ctx) {
     ctx.save();
     ctx.font = "bold 18px arial";
-    ctx.fillStyle = "#FFFFFF";
+    ctx.fillStyle = "#00FF00";
 
     var txt = "" + Game.points;
     var i = pointsLength - txt.length,

--- a/game.js
+++ b/game.js
@@ -125,7 +125,7 @@ var Starfield = function (speed, opacity, numStars, clear) {
   // If the clear option is set,
   // make the background black instead of transparent
   if (clear) {
-    starCtx.fillStyle = "#000";
+    starCtx.fillStyle = "#0F0";
     starCtx.fillRect(0, 0, stars.width, stars.height);
   }
 


### PR DESCRIPTION
## Description:
- Updated game text color to green

This pull request includes several changes to the color scheme used in the game, specifically altering the fill styles in various functions to use different colors.

Changes to color scheme:

* [`engine.js`](diffhunk://#diff-6683a049b66cf3099bf0abddb315e641eabc4fe512082e541a1dfdca072c1445L193-R193): Updated the `TitleScreen` function to use a green color (`#00FF00`) instead of white (`#FFFFFF`) for the fill style.
* [`engine.js`](diffhunk://#diff-6683a049b66cf3099bf0abddb315e641eabc4fe512082e541a1dfdca072c1445L483-R483): Modified the `GamePoints` function to use a green color (`#00FF00`) instead of white (`#FFFFFF`) for the fill style.
* [`game.js`](diffhunk://#diff-90096df085a22d3734b4eaf6ea3ec3395e0fb2c6418a262d84c1c567d10f48bbL128-R128): Changed the `Starfield` function to use a green color (`#0F0`) instead of black (`#000`) for the fill style when the clear option is set.